### PR TITLE
Remove redundant Firmata include

### DIFF
--- a/CircuitPlaygroundFirmata/CircuitPlaygroundFirmata.ino
+++ b/CircuitPlaygroundFirmata/CircuitPlaygroundFirmata.ino
@@ -32,7 +32,6 @@
 #include <SPI.h>
 #include <Servo.h>
 #include <Wire.h>
-#include <Firmata.h>
 #include <Adafruit_CircuitPlayground.h>
 
 // Uncomment below to enable debug output.


### PR DESCRIPTION
On Arduino 1.6.12, attempts to load the CircuitPlaygroundFirmata result in many 'multiple definition' errors (also reported in this Adafruit support thread by another user: https://forums.adafruit.com/viewtopic.php?f=58&t=104379&p=522882&hilit=firmata#p522882). As suggested by adafruit_support_mike, the Firmata library is part of the standard Arduino library now and needn't be included explicitly. Sure enough, removing the #include <Firmata.h> line and re-uploading resulted in a successful upload.
