### PR TITLE
Circuit Playground Classic - custom impl version

### DIFF
--- a/CircuitPlaygroundFirmata/CircuitPlaygroundFirmata.ino
+++ b/CircuitPlaygroundFirmata/CircuitPlaygroundFirmata.ino
@@ -618,7 +618,7 @@ void circuitPlaygroundCommand(byte command, byte argc, byte* argv) {
       noTone(SPEAKER_PIN);
       break;
     case CP_IMPL_VERS:
-      sendImplemenationVersionResponse();
+      sendImplementationVersionResponse();
       break;
     case CP_ACCEL_READ:
       sendAccelResponse();
@@ -725,7 +725,7 @@ void sendColorSenseResponse() {
 }
 
 // Read the version and send a response packet
-void sendImplemenationVersionResponse() {
+void sendImplementationVersionResponse() {
   // Construct a response data packet and send it.
   uint8_t data[4] = {0};
   data[0] = CP_IMPL_VERS_REPLY;

--- a/CircuitPlaygroundFirmata/CircuitPlaygroundFirmata.ino
+++ b/CircuitPlaygroundFirmata/CircuitPlaygroundFirmata.ino
@@ -29,6 +29,8 @@
   See file LICENSE.txt for further informations on licensing terms.
 */
 
+uint8_t IMPLEMENTATION_VERSION[3] = { 8, 29, 19 }; // semver: maj, min, fix
+
 #include <SPI.h>
 #include <Servo.h>
 #include <Wire.h>
@@ -119,7 +121,8 @@
                                       //  - red color (unsigned 8 bit value, split across 2 7-bit bytes)
                                       //  - green color (unsigned 8 bit value, split across 2 7-bit bytes)
                                       //  - blue color (unsigned 8 bit value, split across 2 7-bit bytes)
-
+#define CP_IMPL_VERS            0x60  // Get the implementation version
+#define CP_IMPL_VERS_REPLY      0x61  // 3 bytes from IMPLEMENTATION_VERSION
 
 // the minimum interval for sampling analog input
 #define MINIMUM_SAMPLING_INTERVAL   1
@@ -614,6 +617,9 @@ void circuitPlaygroundCommand(byte command, byte argc, byte* argv) {
       // Stop tone playback.
       noTone(SPEAKER_PIN);
       break;
+    case CP_IMPL_VERS:
+      sendImplemenationVersionResponse();
+      break;
     case CP_ACCEL_READ:
       sendAccelResponse();
       break;
@@ -714,6 +720,18 @@ void sendColorSenseResponse() {
   data[1] = red;
   data[2] = green;
   data[3] = blue;
+  // Send the response.
+  Firmata.sendSysex(CP_COMMAND, 4, data);
+}
+
+// Read the version and send a response packet
+void sendImplemenationVersionResponse() {
+  // Construct a response data packet and send it.
+  uint8_t data[4] = {0};
+  data[0] = CP_IMPL_VERS_REPLY;
+  data[1] = IMPLEMENTATION_VERSION[0];
+  data[2] = IMPLEMENTATION_VERSION[1];
+  data[3] = IMPLEMENTATION_VERSION[2];
   // Send the response.
   Firmata.sendSysex(CP_COMMAND, 4, data);
 }

--- a/CircuitPlaygroundFirmata/CircuitPlaygroundFirmata.ino
+++ b/CircuitPlaygroundFirmata/CircuitPlaygroundFirmata.ino
@@ -29,7 +29,7 @@
   See file LICENSE.txt for further informations on licensing terms.
 */
 
-uint8_t IMPLEMENTATION_VERSION[3] = { 8, 29, 19 }; // semver: maj, min, fix
+uint8_t IMPLEMENTATION_VERSION[3] = { 10, 30, 19 }; // semver: maj, min, fix
 
 #include <SPI.h>
 #include <Servo.h>


### PR DESCRIPTION
This PR is a companion to: https://github.com/adafruit/CircuitPlaygroundFirmata/commit/e23f7ff66abb940aa2b4ec36d9fe09ca7256e3bb

Testing Story:
I tested these changes on a local branch that also included this PR (https://github.com/adafruit/CircuitPlaygroundFirmata/pull/9) so I was able to test that a Circuit Playground Classic flashed with this code could receive the implementation version request command and send the `IMPLEMENTATION_VERSION` back.

Open Question:
I updated the `IMPLEMENTATION_VERSION` to be the date I opened this PR to indicate that this is the most recent version of this firmata. I am not exactly sure what the general plan is for updating this value, so please let me know if there is a preference for a different updating protocol or for it to remain in sync with the Circuit Playground Express Firmata implementation version.