### PR TITLE
Fix A10 feature in Firmata

### DIFF
--- a/CircuitPlaygroundFirmata/CircuitPlaygroundFirmata.ino
+++ b/CircuitPlaygroundFirmata/CircuitPlaygroundFirmata.ino
@@ -1171,8 +1171,7 @@ void setup()
 
   // Tell Firmata to ignore pins that are used by the Circuit Playground hardware.
   // This MUST be called or else Firmata will 'clobber' pins like the SPI CS!
-  pinConfig[28] = PIN_MODE_IGNORE;   // Pin 28 = D8 = LIS3DH CS
-  pinConfig[26] = PIN_MODE_IGNORE;   // Messes with CS too?
+  pinConfig[26] = PIN_MODE_IGNORE;   // Pin 26 = A8 = D8 = LIS3DH CS (circuitplay32u4/pins_arduino.h)
 
 
   systemResetCallback();  // reset to default config


### PR DESCRIPTION
In systemResetCallback()
Code will try to initialize all pins. On Atmega32U4, the last 11 pins, 18~29, are analog. So we do need to protect pin 26, which is also A8, D8, LIS3DH CS to make LIS3DH work. But make pin 28 PIN_MODE_IGNORE will disable analog function on A10. 28 is physical pin number of D8 on the chip, which has nothing to do with pinConfig.